### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v3.0.2
+    - uses: actions/cache@v3.0.8
       with:
         path: |
           ~/.m2/repository
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.4.1
       with:
         java-version: '17'
         distribution: 'adopt'
@@ -25,7 +25,7 @@ jobs:
     - name: Copy site index
       run: cp -v site/index.md com.github.glhez.eclipse.releng.updatesite/target/repository
     - name: Publish generated content to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@4.1.4
+      uses: JamesIves/github-pages-deploy-action@v4.4.0
       with:
         branch: gh-pages
         folder: com.github.glhez.eclipse.releng.updatesite/target/repository


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.8](https://github.com/actions/cache/releases/tag/v3.0.8) on 2022-08-22T06:49:51Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.4.1](https://github.com/actions/setup-java/releases/tag/v3.4.1) on 2022-07-11T14:03:57Z
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release [v4.4.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.4.0) on 2022-07-21T11:22:28Z
