### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Set up JDK 17
-      uses: actions/setup-java@v3.4.1
+      uses: actions/setup-java@v3.5.0
       with:
         java-version: '17'
         distribution: 'adopt'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.5.0](https://github.com/actions/setup-java/releases/tag/v3.5.0) on 2022-09-08T13:59:11Z
