### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3.0.2
-    - uses: actions/cache@v3.0.8
+    - uses: actions/cache@v3.0.9
       with:
         path: |
           ~/.m2/repository
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Set up JDK 17
-      uses: actions/setup-java@v3.4.1
+      uses: actions/setup-java@v3.5.1
       with:
         java-version: '17'
         distribution: 'adopt'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.9](https://github.com/actions/cache/releases/tag/v3.0.9) on 2022-09-30T05:19:40Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.5.1](https://github.com/actions/setup-java/releases/tag/v3.5.1) on 2022-09-26T14:07:25Z
