### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -12,13 +12,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v2.5.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.5.6
+        uses: saadmk11/github-actions-version-updater@v0.7.1
         with:
           # Optional, allows customizing the commit message and pull request title
           # Both default to 'Update GitHub Action Versions'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
-    - uses: actions/cache@v3.0.8
+    - uses: actions/checkout@v2.5.0
+    - uses: actions/cache@v3.0.11
       with:
         path: |
           ~/.m2/repository
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Set up JDK 17
-      uses: actions/setup-java@v3.4.1
+      uses: actions/setup-java@v3.6.0
       with:
         java-version: '17'
         distribution: 'adopt'
@@ -25,7 +25,7 @@ jobs:
     - name: Copy site index
       run: cp -v site/index.md com.github.glhez.eclipse.releng.updatesite/target/repository
     - name: Publish generated content to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.4.0
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:
         branch: gh-pages
         folder: com.github.glhez.eclipse.releng.updatesite/target/repository


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release [v0.7.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.1) on 2022-10-29T16:38:42Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.6.0](https://github.com/actions/setup-java/releases/tag/v3.6.0) on 2022-10-18T12:22:48Z
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release [v4.4.1](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.4.1) on 2022-10-13T03:31:44Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11) on 2022-10-13T11:18:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
