### PR TITLE
update github workflows actions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.2.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v3.2.0
+    - uses: actions/cache@v3.2.2
       with:
         path: |
           ~/.m2/repository
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v3.9.0
       with:
         java-version: '17'
         distribution: 'adopt'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.2.0](https://github.com/actions/checkout/releases/tag/v3.2.0)** on 2022-12-12T19:14:01Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.9.0](https://github.com/actions/setup-java/releases/tag/v3.9.0)** on 2022-12-14T13:33:59Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.2.2](https://github.com/actions/cache/releases/tag/v3.2.2)** on 2022-12-27T11:11:11Z
