### PR TITLE
update github workflows actions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -12,13 +12,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.0.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.8.0
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # Optional, allows customizing the commit message and pull request title
           # Both default to 'Update GitHub Action Versions'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.3
-    - uses: actions/cache@v3.3.1
+    - uses: actions/checkout@v4.0.0
+    - uses: actions/cache@v3.3.2
       with:
         path: |
           ~/.m2/repository


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.2](https://github.com/actions/cache/releases/tag/v3.3.2)** on 2023-09-07T20:33:08Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
